### PR TITLE
add 404 redirect, router testing wrapper

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<title>Single Page Apps for GitHub Pages</title>
+	<script type="text/javascript">
+		// Single Page Apps for GitHub Pages
+		// MIT License
+		// https://github.com/rafgraph/spa-github-pages
+		// This script takes the current url and converts the path and query
+		// string into just a query string, and then redirects the browser
+		// to the new url with only a query string and hash fragment,
+		// e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+		// https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+		// Note: this 404.html file must be at least 512 bytes for it to work
+		// with Internet Explorer (it is currently > 512 bytes)
+
+		// If you're creating a Project Pages site and NOT using a custom domain,
+		// then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+		// This way the code will only replace the route part of the path, and not
+		// the real directory in which the app resides, for example:
+		// https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+		// https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+		// Otherwise, leave pathSegmentsToKeep as 0.
+		var pathSegmentsToKeep = 1;
+
+		var l = window.location;
+		l.replace(
+			l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+			l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+			l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+			(l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+			l.hash
+		);
+
+	</script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,13 +1,40 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Orchestra of the Age of Enlightenment Programme</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <title>Orchestra of the Age of Enlightenment Programme</title>
+
+  <!-- Start Single Page Apps for GitHub Pages -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // MIT License
+    // https://github.com/rafgraph/spa-github-pages
+    // This script checks to see if a redirect is present in the query string,
+    // converts it back into the correct url and adds it to the
+    // browser's history using window.history.replaceState(...),
+    // which won't cause the browser to attempt to load the new url.
+    // When the single page app is loaded further down in this file,
+    // the correct url will be waiting in the browser's history for
+    // the single page app to route accordingly.
+    (function (l) {
+      if (l.search[1] === '/') {
+        var decoded = l.search.slice(1).split('&').map(function (s) {
+          return s.replace(/~and~/g, '&')
+        }).join('?');
+        window.history.replaceState(null, null,
+          l.pathname.slice(0, -1) + decoded + l.hash
+        );
+      }
+    }(window.location))
+  </script>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,23 +1,17 @@
-import './App.scss';
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import Home from './pages/Home/Home';
-import About from './pages/About/About';
-import Schedule from './pages/Schedule/Schedule';
+import { Route, Routes } from "react-router-dom";
+import "./App.scss";
+import About from "./pages/About/About";
+import Home from "./pages/Home/Home";
+import Schedule from "./pages/Schedule/Schedule";
 
-const  App = () => {
-  const baseURL = "/oae-event-programme";
-  return ( 
-    <Router>
-    <div className="App">
-      <Routes>
-        <Route path={baseURL} element={<Home />}/>
-        <Route path={baseURL +"/our-story"} element={<About/>} />
-        <Route path={baseURL + "/event-schedule"} element={<Schedule />} />
-        <Route path={baseURL +"*"} element={<Home/>} />
-      </Routes>
-    </div>
-    </Router>
-    
+const App = () => {
+  return (
+    <Routes>
+      <Route index element={<Home />} />
+      <Route path="/our-story" element={<About />} />
+      <Route path="/event-schedule" element={<Schedule />} />
+      <Route path="/*" element={<Home />} />
+    </Routes>
   );
 };
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,7 @@
-import { render } from "@testing-library/react";
 import App from "./App";
+import { customRender } from "./utils/testUtils";
 
-test("Renders App component", () => {
-  const { container } = render(<App />);
+test("Renders App component with default page", () => {
+  const { container } = customRender(<App />);
   expect(container).toMatchSnapshot();
 });

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Renders App component 1`] = `
+exports[`Renders App component with default page 1`] = `
 <div>
-  <div
-    class="App"
-  />
+  <div>
+    <h1>
+      Home page
+    </h1>
+  </div>
 </div>
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const baseURL = "/oae-event-programme";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Router basename={baseURL}>
+      <App />
+    </Router>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/utils/testUtils.js
+++ b/src/utils/testUtils.js
@@ -1,0 +1,14 @@
+import { render } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+export const customRender = (ui, useRouting = true) => {
+  // wrap components in routing if requested
+  const uiResult = useRouting && wrapWithRouting(ui);
+
+  // use RTL's render function to return the test component
+  return render(uiResult);
+};
+
+const wrapWithRouting = (ui) => {
+  return <Router>{ui}</Router>;
+};


### PR DESCRIPTION
- When deploying to GH-Pages we need to include a 404.html to override GitHub's built-in redirect to a 404 page
- That means slightly change how we setup the routing. I've moved the Router component to index.js which means we can create mocks for it in our App tests.